### PR TITLE
Fixed typographical error, changed auxilliary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Main projects:
  - jspointers: pointer analysis for JavaScript
  - jsrefactoring: refactoring logic
 
-Auxilliary projects:
+Auxiliary projects:
  - jsutil: some stuff all projects need
  - jtidy-js: hacked version of jtidy, needed to extract JavaScript from HTML files
  - benchmarks: refactoring benchmarks used in the OOPSLA'11 paper


### PR DESCRIPTION
cs-au-dk, I've corrected a typographical error in the documentation of the [JSRefactor](https://github.com/cs-au-dk/JSRefactor) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
